### PR TITLE
Update roles to v3

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -20,7 +20,7 @@ shell-server@0.5.0            # Server-side component of the `meteor shell` comm
 # ACCOUNTS
 accounts-base@1.6.0
 accounts-password@1.6.0
-alanning:roles
+alanning:roles@3.2.2
 leaonline:oauth2-server
 
 # UI

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,6 +1,6 @@
 accounts-base@1.6.0
 accounts-password@1.6.0
-alanning:roles@1.2.19
+alanning:roles@3.2.2
 aldeed:autoform@6.3.0
 aldeed:template-extension@4.1.0
 allow-deny@1.1.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# leaonline-accounts
+# lea.online Accounts
+
+## Roles system
+
+There are four main roles within the lea.system. The roles are placed within
+a hierarchy of access, where the top-most role has the least restricted permissions:
+
+1. Administrators (`admin`) - no restriction
+2. Core team members (`team`) - can't manage roles and users but backend and classes
+3. Course instructors (`teacher`) - can only manage classes
+4. Particpants (`user`) - no special permissions
+
+A future `test` role is to be added in order to separate "real" users from
+test users. This role needs to include a special permission of deleting
+all test data that is associated with the test user.
+
+###### Developers note:
+
+In the code the roles are named `Personas` in order to keep this
+separated from the `Roles` API, that defined by the `alanning:roles` package.

--- a/imports/api/roles/Permissions.js
+++ b/imports/api/roles/Permissions.js
@@ -1,0 +1,30 @@
+export const Permissions = {}
+
+// ROLES
+Permissions.roles = {}
+Permissions.roles.add = 'addRoles'
+Permissions.roles.edit = 'editRoles'
+Permissions.roles.delete = 'deleteRoles'
+
+// USERS
+Permissions.users = {}
+Permissions.users.add = 'addUsers'
+Permissions.users.edit = 'editUsers'
+Permissions.users.delete = 'deleteUsers'
+Permissions.users.invite = 'inviteUsers'
+
+// BACKEND
+Permissions.backend = {}
+Permissions.backend.access = 'accessBackend'
+Permissions.backend.apps = 'editApps'
+Permissions.backend.sets = 'manageSets'
+Permissions.backend.units = 'manageUnits'
+Permissions.backend.competencies = 'manageCompetencies'
+Permissions.backend.scoring = 'manageScoring'
+Permissions.backend.evaluation = 'manageEvaluation'
+
+// COURSES / CLASSES
+Permissions.classes = {}
+Permissions.classes.manage = 'manageClasses'
+Permissions.classes.repsonses = 'readOthersResponses'
+Permissions.classes.evaluation = 'readOthersEvaluations'

--- a/imports/api/roles/Personas.js
+++ b/imports/api/roles/Personas.js
@@ -1,0 +1,43 @@
+/**
+ * A Persona is like a role but in order to avoid confusion withe the {Roles} api
+ * we use the more psychological oriented term "Persona".
+ */
+
+export const Personas = {}
+
+/**
+ * Admin has the unrestricted permissions level (0) and can perform any operations.
+ */
+
+Personas.admin = {
+  level: 0,
+  name: 'admin'
+}
+
+/**
+ * A team member is a person of the lea. core team which has less permissions than an Administrator but
+ * should access to the applications backend and edit content.
+ */
+Personas.team = {
+  level: 1,
+  name: 'team'
+}
+
+/**
+ * A teacher is a person that uses the dashboard and should have read access to the participant's data.
+ */
+
+Personas.teacher = {
+  level: 2,
+  name: 'teacher'
+}
+
+/**
+ * A user represents the most restricted person within the system. Usually this person is a participant
+ * that solves units and sends responses.
+ */
+
+Personas.user = {
+  level: 3,
+  name: 'user'
+}

--- a/imports/startup/server/roles.js
+++ b/imports/startup/server/roles.js
@@ -1,0 +1,44 @@
+/* global Roles */
+import { Personas } from '../../api/roles/Personas'
+import { Permissions } from '../../api/roles/Permissions'
+
+const createRole = name => {
+  if (Meteor.roles.findOne(name)) return
+  Roles.createRole(name)
+  console.info(`[Roles]: created top-level role ${name}`)
+}
+
+// first we ensure all top-level roles are represented by a persona
+Object.values(Personas).forEach(({ name }) => createRole(name))
+
+// then we go by each and assign default permissions
+// note, that admin should be able to add/edit/remove permissions
+// so we can have this default by convention and let admins config
+
+const assignRoles = (persona, namespaces) => {
+  namespaces.forEach(namespace => {
+    Object.values(namespace).forEach(permission => {
+      // if not already created, create new role on this permission
+      createRole(permission)
+
+      // if the persona already obtained this role as child
+      // just skip the operation at this point
+      if (Meteor.roles.findOne({ _id: persona, children: permission })) {
+        return
+      }
+
+      // otherwise connect the permission with the persona
+      Roles.addRolesToParent(permission, persona)
+      console.info(`[Roles]: ${persona} permission added [${permission}]`)
+    })
+  })
+}
+
+// Admin -> always assign all permissions
+assignRoles(Personas.admin.name, Object.values(Permissions))
+
+// Team members -> all but roles and user mgmt
+assignRoles(Personas.team.name, [Permissions.backend, Permissions.classes])
+
+// Teachers
+assignRoles(Personas.teacher.name, [Permissions.classes])

--- a/server/main.js
+++ b/server/main.js
@@ -1,2 +1,3 @@
+import '../imports/startup/server/roles'
 import '../imports/startup/server/accounts'
 import '../imports/startup/server/oauth'


### PR DESCRIPTION
This PR updates the `alanning:roles` package to version 3 and implements a default set of roles / permissions for the accounts. Note: no accounts have been assigned with these roles yet, because this is to be done in another PR.

README has been updated, too.